### PR TITLE
Clarify JSON annotation processing in fs.py

### DIFF
--- a/src/seamless_interaction/fs.py
+++ b/src/seamless_interaction/fs.py
@@ -986,11 +986,12 @@ class SeamlessInteractionFS:
                         shared_json_data[f"metadata:{metadata_type}"] = lines
 
             elif filename.endswith(".json"):
-                # Process JSON annotations
+                # These annotation files are actually multi-line JSON (JSONL)
                 if not self._dry_run:
                     with open(tmp_file_path, "r") as f:
-                        data = json.load(f)
-
+                        # Load line-by-line — each line is a JSON object
+                        data = [json.loads(line) for line in f if line.strip()]
+                    
                     # Extract annotation type from path
                     path_parts = url.split("/")
                     annotation_type = path_parts[-2]  # e.g., "1P-IS"


### PR DESCRIPTION
Updated comment to clarify that annotation files are multi-line JSON (JSONL) and adjusted JSON loading to process line-by-line.

## Why?
Please refer to my issue: https://github.com/facebookresearch/seamless_interaction/issues/28. 

Those annotation files claimed to be JSON but are actually JSONL, which makes downloading from s3 a little bit tricky.

## How ?
I directly treat annotation files on s3 as JSONL files. 

## Test plan
After this modification, at least using `download_s3.py` is ok, including function `download_single_example`, `download_interaction_pair`, `download_samples_1gb` and `download_session_exploration`.
